### PR TITLE
Better lane detection for early game

### DIFF
--- a/gleague/gleague/models/match.py
+++ b/gleague/gleague/models/match.py
@@ -100,8 +100,11 @@ class PlayerMatchStats(db.Model):
             self.match_id,
         )
 
+    def is_radiant(self):
+        return self.player_slot < 5
+
     def is_winner(self):
-        return self.match.radiant_win == (self.player_slot < 5)
+        return self.match.radiant_win == self.is_radiant()
 
 
 class PlayerMatchRating(db.Model):

--- a/gleague/gleague/replays.py
+++ b/gleague/gleague/replays.py
@@ -128,7 +128,8 @@ class ReplayDataProcessor:
                 setattr(player_stats, key, player_data[key])
             player_stats.hero = player_data["hero_name"].replace("npc_dota_hero_", "")
             player_stats.position = detect_position(
-                list([[pos["x"], pos["y"]] for pos in player_stats.movement])
+                list([[pos["x"], pos["y"]] for pos in player_stats.movement]),
+                player_stats.is_radiant(),
             )
             match_player_items_map = {
                 mpi.name: mpi for mpi in player_stats.player_match_items

--- a/gleague/gleague/replays.py
+++ b/gleague/gleague/replays.py
@@ -128,8 +128,7 @@ class ReplayDataProcessor:
                 setattr(player_stats, key, player_data[key])
             player_stats.hero = player_data["hero_name"].replace("npc_dota_hero_", "")
             player_stats.position = detect_position(
-                list([[pos["x"], pos["y"]] for pos in player_stats.movement]),
-                player_stats.is_radiant(),
+                list([[pos["x"], pos["y"]] for pos in player_stats.movement])
             )
             match_player_items_map = {
                 mpi.name: mpi for mpi in player_stats.player_match_items

--- a/gleague/gleague/utils/position.py
+++ b/gleague/gleague/utils/position.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 from collections import Counter
 from typing import Optional, List
 
-from sklearn.cluster import KMeans
-import numpy as np
+
+MID_THRESHOLD = 2000
 
 
 class Position(enum.Enum):
@@ -12,37 +12,23 @@ class Position(enum.Enum):
     bottom = "bottom"
     middle = "middle"
     roam = "roam"
-    safelane = "safelane"
-    offlane = "offlane"
 
 
-positions_radiant = OrderedDict(
-    {
-        (4500, 8000): Position.offlane,
-        (7500, 5500): Position.safelane,
-        (7200, 7200): Position.middle,
-    }
-)
-
-positions_dire = OrderedDict(
-    {
-        (7000, 10000): Position.safelane,
-        (10500, 8000): Position.offlane,
-        (7200, 7200): Position.middle,
-    }
-)
+def point_position(point: List[int]):
+    if abs(pair[0] - pair[1]) < MID_THRESHOLD:
+        return Position.middle
+    if pair[0] - pair[1] < 0:
+        return Position.top
+    return Position.bottom
 
 
-def detect_position(points: List[dict], is_radiant: bool) -> Optional[Position]:
+def detect_position(points: List[List[int]]) -> Optional[Position]:
     if not points:
         return None
-    positions = positions_radiant if is_radiant else positions_dire
-    init = np.array(list(positions.keys()))
-    kmeans = KMeans(n_clusters=3, init=init)
-    result = kmeans.fit(points).labels_
+    result = [point_position(point) for point in points]
     most_common, num_most_common = Counter(result).most_common(1)[0]
     if (len(points) / num_most_common) > 0.6:
-        position = list(positions.items())[most_common][-1]
+        position = most_common
     else:
         position = Position.roam
     return position

--- a/gleague/gleague/utils/position.py
+++ b/gleague/gleague/utils/position.py
@@ -15,9 +15,9 @@ class Position(enum.Enum):
 
 
 def point_position(point: List[int]):
-    if abs(pair[0] - pair[1]) < MID_THRESHOLD:
+    if abs(point[0] - point[1]) < MID_THRESHOLD:
         return Position.middle
-    if pair[0] - pair[1] < 0:
+    if point[0] - point[1] < 0:
         return Position.top
     return Position.bottom
 

--- a/gleague/gleague/utils/position.py
+++ b/gleague/gleague/utils/position.py
@@ -12,20 +12,31 @@ class Position(enum.Enum):
     bottom = "bottom"
     middle = "middle"
     roam = "roam"
+    safelane = "safelane"
+    offlane = "offlane"
 
 
-positions = OrderedDict(
+positions_radiant = OrderedDict(
     {
-        (3500, 11000): Position.top,
-        (11500, 4000): Position.bottom,
+        (4500, 8000): Position.offlane,
+        (7500, 5500): Position.safelane,
+        (7200, 7200): Position.middle,
+    }
+)
+
+positions_dire = OrderedDict(
+    {
+        (7000, 10000): Position.safelane,
+        (10500, 8000): Position.offlane,
         (7200, 7200): Position.middle,
     }
 )
 
 
-def detect_position(points: List[dict]) -> Optional[Position]:
+def detect_position(points: List[dict], is_radiant: bool) -> Optional[Position]:
     if not points:
         return None
+    positions = positions_radiant if is_radiant else positions_dire
     init = np.array(list(positions.keys()))
     kmeans = KMeans(n_clusters=3, init=init)
     result = kmeans.fit(points).labels_

--- a/gleague/requirements.txt
+++ b/gleague/requirements.txt
@@ -15,7 +15,6 @@ sqlalchemy-utils==0.34.0
 dogpile.cache==0.7.1
 redis==3.3.4
 werkzeug==0.14.1
-sklearn==0.0
 gunicorn==19.9.0
 gevent==1.3.4
 greenlet==0.4.13


### PR DESCRIPTION
Tried to fix position detection for laning phase, ended up switching to safe/mid/off scheme since prev scheme is kinda harder to understand and felt a bit out of date.
Used separate clusters for dire/radiant for better detection, moved clusters centers closer to respective jungle parts so k-means picks cluster closer to sidelanes even if core/supp went jungling/stacking/bounty/etc.