### PR TITLE
Season filters and player links

### DIFF
--- a/gleague/gleague/frontend/players.py
+++ b/gleague/gleague/frontend/players.py
@@ -5,29 +5,101 @@ from flask import abort
 from flask import current_app
 from flask import render_template
 from flask import request
-from sqlalchemy import desc
+from sqlalchemy import desc, and_, or_
+from sqlalchemy.orm import aliased
 
 from gleague.models import Player
 from gleague.models import PlayerMatchStats
 from gleague.models import Season
 from gleague.models import SeasonStats
+from gleague.models import Role
 from gleague.models.queries import player_analytic
 from gleague.models.queries.season_analytic import get_signature_teammates
 from gleague.models.queries.season_analytic import get_signature_opponents
 from gleague.models.queries.season_analytic import SignatureTeammatesOrder
 from gleague.models.queries.season_analytic import SignatureOpponentOrder
 from gleague.models.queries.season_analytic import get_playstyles
+from gleague.utils.position import Position
 
 
 players_bp = Blueprint("players", __name__)
 
 
-def get_season_stats(current_season_id, player):
-    stats = player.season_stats.all()
-    if not stats or stats[0].season_id != current_season_id:
+def get_season_stats(season_id, player):
+    """
+    Return stats for a specific season if season_id is not None,
+    otherwise return overall aggregated stats across all seasons.
+    """
+    if season_id is not None:
+        stats = (
+            player.season_stats.filter(SeasonStats.season_id == season_id).first()
+        )
+        if not stats:
+            return {"wins": 0, "losses": 0, "pts": 1000}
+        return stats
+
+    # overall stats across all seasons: compute wins / losses from
+    # actual matches so they are consistent with heroes & matches tabs
+    stats_list = player.season_stats.all()
+    if not stats_list:
         return {"wins": 0, "losses": 0, "pts": 1000}
+
+    wins_losses_query = (
+        PlayerMatchStats.query.join(SeasonStats)
+        .filter(SeasonStats.steam_id == player.steam_id)
+    )
+    wins = wins_losses_query.filter(PlayerMatchStats.pts_diff > 0).count()
+    losses = wins_losses_query.filter(PlayerMatchStats.pts_diff < 0).count()
+
+    return {
+        "wins": wins,
+        "losses": losses,
+        # show current rating (latest season by default ordering)
+        "pts": stats_list[0].pts,
+    }
+
+
+def _get_season_selection():
+    """
+    Parse `season` query param.
+
+    Returns dict with:
+      - season_id: Season.id or None for overall
+      - season_number: Season.number or None for overall
+      - season_param: original string for URLs (e.g. "3", "overall", or None)
+      - is_overall: bool
+      - seasons: list of Season objects (all seasons, newest first)
+    """
+    season_param = request.args.get("season")
+    current_season = Season.current()
+    seasons = Season.query.order_by(Season.number.desc()).all()
+
+    is_overall = False
+    selected_season = None
+
+    if season_param is None:
+        selected_season = current_season
+    elif season_param == "overall":
+        is_overall = True
+    elif season_param.isdigit():
+        selected_season = Season.query.filter(
+            Season.number == int(season_param)
+        ).first()
+        if not selected_season:
+            abort(404)
     else:
-        return stats[0]
+        abort(400)
+
+    season_id = selected_season.id if selected_season is not None else None
+    season_number = selected_season.number if selected_season is not None else None
+
+    return {
+        "season_id": season_id,
+        "season_number": season_number,
+        "season_param": season_param,
+        "is_overall": is_overall,
+        "seasons": seasons,
+    }
 
 
 @players_bp.route("/<int:steam_id>/", methods=["GET"])
@@ -37,51 +109,60 @@ def overview(steam_id):
     if not player:
         return abort(404)
     current_season_id = Season.current().id
+    season_ctx = _get_season_selection()
+    season_id = season_ctx["season_id"]
     matches_stats = (
         PlayerMatchStats.query.join(SeasonStats)
         .filter(SeasonStats.steam_id == steam_id)
+        .filter(
+            SeasonStats.season_id == season_id
+            if season_id is not None
+            else True
+        )
         .order_by(desc(PlayerMatchStats.match_id))
         .limit(current_app.config["PLAYER_OVERVIEW_MATCHES_AMOUNT"])
         .all()
     )
     signature_heroes = (
-        player_analytic.get_heroes(player.steam_id, current_season_id)
+        player_analytic.get_heroes(player.steam_id, season_id)
         .order_by(desc("played"))
         .limit(3)
         .all()
     )
-    avg_rating, rating_amount = player_analytic.get_rating_info(player.steam_id)
+    avg_rating, rating_amount = player_analytic.get_rating_info(
+        player.steam_id, season_id=season_id
+    )
     best_team_mates = get_signature_teammates(
-        current_season_id,
+        season_id,
         SignatureTeammatesOrder.win_loss,
         is_asc=False,
         player_id=steam_id,
         limit=3,
     )
     worst_team_mates = get_signature_teammates(
-        current_season_id,
+        season_id,
         SignatureTeammatesOrder.win_loss,
         player_id=steam_id,
         limit=3,
     )
     losses_to = get_signature_opponents(
-        current_season_id,
+        season_id,
         steam_id,
         SignatureOpponentOrder.win_loss,
         limit=3
     )
     wins_against = get_signature_opponents(
-        current_season_id,
+        season_id,
         steam_id,
         SignatureOpponentOrder.win_loss,
         is_asc=False,
         limit=3,
     )
-    playstyles = get_playstyles(current_season_id, steam_id)
+    playstyles = get_playstyles(season_id, steam_id)
     return render_template(
         "/player/overview.html",
         player=player,
-        season_stats=get_season_stats(current_season_id, player),
+        season_stats=get_season_stats(season_id, player),
         avg_rating=avg_rating,
         rating_amount=rating_amount,
         signature_heroes=signature_heroes,
@@ -92,8 +173,12 @@ def overview(steam_id):
         wins_against=wins_against,
         playstyles=playstyles,
         pts_history=json.dumps(
-            player_analytic.get_pts_history(steam_id, current_season_id)
+            player_analytic.get_pts_history(steam_id, season_id=season_id)
         ),
+        seasons=season_ctx["seasons"],
+        selected_season_number=season_ctx["season_number"],
+        selected_season_param=season_ctx["season_param"],
+        is_overall=season_ctx["is_overall"],
     )
 
 
@@ -107,16 +192,136 @@ def matches(steam_id):
         abort(400)
     page = int(page)
     current_season_id = Season.current().id
+    season_ctx = _get_season_selection()
+    season_id = season_ctx["season_id"]
     matches_stats = (
         PlayerMatchStats.query.order_by(desc(PlayerMatchStats.match_id))
         .join(SeasonStats)
         .filter(SeasonStats.steam_id == steam_id)
+        .filter(
+            SeasonStats.season_id == season_id
+            if season_id is not None
+            else True
+        )
     )
-    template_context = {"player": player}
-    hero_filter = request.args.get("hero", None)
+    template_context = {
+        "player": player,
+        "seasons": season_ctx["seasons"],
+        "selected_season_number": season_ctx["season_number"],
+        "selected_season_param": season_ctx["season_param"],
+        "is_overall": season_ctx["is_overall"],
+    }
+    hero_filter = request.args.get("hero")
     if hero_filter:
         template_context["hero_filter"] = hero_filter
         matches_stats = matches_stats.filter(PlayerMatchStats.hero == hero_filter)
+
+    # Optional role filter (Playstyle section)
+    role_filter = request.args.get("role")
+    if role_filter:
+        template_context["role_filter"] = role_filter
+        if role_filter == "Support":
+            matches_stats = matches_stats.filter(
+                PlayerMatchStats.role == Role.support
+            )
+        elif role_filter == "Midlane":
+            matches_stats = matches_stats.filter(
+                PlayerMatchStats.role == Role.core,
+                PlayerMatchStats.position == Position.middle,
+            )
+        elif role_filter == "Safelane":
+            matches_stats = matches_stats.filter(
+                PlayerMatchStats.role == Role.core,
+                or_(
+                    and_(
+                        PlayerMatchStats.position == Position.bottom,
+                        PlayerMatchStats.player_slot < 5,
+                    ),
+                    and_(
+                        PlayerMatchStats.position == Position.top,
+                        PlayerMatchStats.player_slot > 5,
+                    ),
+                ),
+            )
+        elif role_filter == "Offlane":
+            matches_stats = matches_stats.filter(
+                PlayerMatchStats.role == Role.core,
+                or_(
+                    and_(
+                        PlayerMatchStats.position == Position.bottom,
+                        PlayerMatchStats.player_slot > 5,
+                    ),
+                    and_(
+                        PlayerMatchStats.position == Position.top,
+                        PlayerMatchStats.player_slot < 5,
+                    ),
+                ),
+            )
+
+    # Optional teammate / opponent filters (Signature teammates/opponents)
+    teammate_id = request.args.get("teammate")
+    if teammate_id:
+        if not teammate_id.isdigit():
+            abort(400)
+        teammate_id_int = int(teammate_id)
+        template_context["teammate_id"] = teammate_id_int
+        pms2 = aliased(PlayerMatchStats)
+        ss2 = aliased(SeasonStats)
+        matches_stats = (
+            matches_stats.join(
+                pms2,
+                pms2.match_id == PlayerMatchStats.match_id,
+            )
+            .join(
+                ss2,
+                ss2.id == pms2.season_stats_id,
+            )
+            .filter(
+                ss2.steam_id == teammate_id_int,
+                or_(
+                    and_(
+                        PlayerMatchStats.player_slot < 5,
+                        pms2.player_slot < 5,
+                    ),
+                    and_(
+                        PlayerMatchStats.player_slot >= 5,
+                        pms2.player_slot >= 5,
+                    ),
+                ),
+            )
+        )
+
+    opponent_id = request.args.get("opponent")
+    if opponent_id:
+        if not opponent_id.isdigit():
+            abort(400)
+        opponent_id_int = int(opponent_id)
+        template_context["opponent_id"] = opponent_id_int
+        pms3 = aliased(PlayerMatchStats)
+        ss3 = aliased(SeasonStats)
+        matches_stats = (
+            matches_stats.join(
+                pms3,
+                pms3.match_id == PlayerMatchStats.match_id,
+            )
+            .join(
+                ss3,
+                ss3.id == pms3.season_stats_id,
+            )
+            .filter(
+                ss3.steam_id == opponent_id_int,
+                or_(
+                    and_(
+                        PlayerMatchStats.player_slot < 5,
+                        pms3.player_slot >= 5,
+                    ),
+                    and_(
+                        PlayerMatchStats.player_slot >= 5,
+                        pms3.player_slot < 5,
+                    ),
+                ),
+            )
+        )
     template_context["matches_stats"] = matches_stats.paginate(
         page, current_app.config["PLAYER_HISTORY_MATCHES_PER_PAGE"], True
     )
@@ -124,7 +329,7 @@ def matches(steam_id):
         template_context["avg_rating"],
         template_context["rating_amount"],
     ) = player.get_rating_info()
-    template_context["season_stats"] = get_season_stats(current_season_id, player)
+    template_context["season_stats"] = get_season_stats(season_id, player)
     return render_template("/player/matches.html", **template_context)
 
 
@@ -142,8 +347,10 @@ def heroes(steam_id):
         is_desc = "yes"
         order_by = desc(order_by)
     current_season_id = Season.current().id
+    season_ctx = _get_season_selection()
+    season_id = season_ctx["season_id"]
     heroes_stats = (
-        player_analytic.get_heroes(player.steam_id, current_season_id)
+        player_analytic.get_heroes(player.steam_id, season_id)
         .order_by(order_by)
         .all()
     )
@@ -152,9 +359,15 @@ def heroes(steam_id):
         "sort": sort,
         "desc": is_desc,
         "heroes_stats": heroes_stats,
-        "season_stats": get_season_stats(current_season_id, player),
+        "season_stats": get_season_stats(season_id, player),
+        "seasons": season_ctx["seasons"],
+        "selected_season_number": season_ctx["season_number"],
+        "selected_season_param": season_ctx["season_param"],
+        "is_overall": season_ctx["is_overall"],
     }
-    rating_info = player_analytic.get_rating_info(player.steam_id)
+    rating_info = player_analytic.get_rating_info(
+        player.steam_id, season_id=season_id
+    )
     template_context["avg_rating"], template_context["rating_amount"] = rating_info
     return render_template("/player/heroes.html", **template_context)
 
@@ -168,9 +381,11 @@ def opponents(steam_id):
     is_desc = request.args.get("desc", "yes")
     is_asc = is_desc != "yes"
     current_season_id = Season.current().id
+    season_ctx = _get_season_selection()
+    season_id = season_ctx["season_id"]
     order_by = getattr(SignatureOpponentOrder, sort)
     opponents = get_signature_opponents(
-        current_season_id,
+        season_id,
         steam_id,
         order_by,
         is_asc=is_asc,
@@ -180,9 +395,15 @@ def opponents(steam_id):
         "sort": sort,
         "desc": is_desc,
         "opponents": opponents,
-        "season_stats": get_season_stats(current_season_id, player),
+        "season_stats": get_season_stats(season_id, player),
+        "seasons": season_ctx["seasons"],
+        "selected_season_number": season_ctx["season_number"],
+        "selected_season_param": season_ctx["season_param"],
+        "is_overall": season_ctx["is_overall"],
     }
-    rating_info = player_analytic.get_rating_info(player.steam_id)
+    rating_info = player_analytic.get_rating_info(
+        player.steam_id, season_id=season_id
+    )
     template_context["avg_rating"], template_context["rating_amount"] = rating_info
     return render_template("/player/opponents.html", **template_context)
 
@@ -196,9 +417,11 @@ def teammates(steam_id):
     is_desc = request.args.get("desc", "yes")
     is_asc = is_desc != "yes"
     current_season_id = Season.current().id
+    season_ctx = _get_season_selection()
+    season_id = season_ctx["season_id"]
     order_by = getattr(SignatureTeammatesOrder, sort)
     teammates = get_signature_teammates(
-        current_season_id,
+        season_id,
         order_by,
         player_id=steam_id,
         is_asc=is_asc,
@@ -208,8 +431,14 @@ def teammates(steam_id):
         "sort": sort,
         "desc": is_desc,
         "teammates": teammates,
-        "season_stats": get_season_stats(current_season_id, player),
+        "season_stats": get_season_stats(season_id, player),
+        "seasons": season_ctx["seasons"],
+        "selected_season_number": season_ctx["season_number"],
+        "selected_season_param": season_ctx["season_param"],
+        "is_overall": season_ctx["is_overall"],
     }
-    rating_info = player_analytic.get_rating_info(player.steam_id)
+    rating_info = player_analytic.get_rating_info(
+        player.steam_id, season_id=season_id
+    )
     template_context["avg_rating"], template_context["rating_amount"] = rating_info
     return render_template("/player/teammates.html", **template_context)

--- a/gleague/gleague/frontend/templates/_blocks/player_header.html
+++ b/gleague/gleague/frontend/templates/_blocks/player_header.html
@@ -1,22 +1,68 @@
-<ul class="nav nav-tabs bg-white">
-    <li class="nav-item">
-        <a class="nav-link {{ 'active' if endpoint[1] == 'overview' else None }}"
-           href="{{ url_for('players.overview', steam_id=player.steam_id) }}">Overview</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link {{ 'active' if endpoint[1] == 'heroes' else None }}"
-           href="{{ url_for('players.heroes', steam_id=player.steam_id) }}">Heroes</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link {{ 'active' if endpoint[1] == 'matches' else None }}"
-           href="{{ url_for('players.matches', steam_id=player.steam_id) }}">Matches</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link {{ 'active' if endpoint[1] == 'teammates' else None }}"
-           href="{{ url_for('players.teammates', steam_id=player.steam_id) }}">Teammates</a>
-    </li>
-    <li class="nav-item">
-        <a class="nav-link {{ 'active' if endpoint[1] == 'opponents' else None }}"
-           href="{{ url_for('players.opponents', steam_id=player.steam_id) }}">Opponents</a>
-    </li>
-</ul>
+<div class="d-flex justify-content-between align-items-center bg-white">
+    <ul class="nav nav-tabs">
+        {% set season_arg = selected_season_param %}
+        <li class="nav-item">
+            <a class="nav-link {{ 'active' if endpoint[1] == 'overview' else None }}"
+               href="{{ url_for('players.overview', steam_id=player.steam_id, season=season_arg) }}">Overview</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ 'active' if endpoint[1] == 'heroes' else None }}"
+               href="{{ url_for('players.heroes', steam_id=player.steam_id, season=season_arg) }}">Heroes</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ 'active' if endpoint[1] == 'matches' else None }}"
+               href="{{ url_for('players.matches', steam_id=player.steam_id, season=season_arg) }}">Matches</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ 'active' if endpoint[1] == 'teammates' else None }}"
+               href="{{ url_for('players.teammates', steam_id=player.steam_id, season=season_arg) }}">Teammates</a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link {{ 'active' if endpoint[1] == 'opponents' else None }}"
+               href="{{ url_for('players.opponents', steam_id=player.steam_id, season=season_arg) }}">Opponents</a>
+        </li>
+    </ul>
+    <div class="form-inline mr-3">
+        <label for="season-select" class="mr-2 mb-0">Season:</label>
+        <select id="season-select" class="form-control form-control-sm">
+            <option value=""
+                {% if not selected_season_param and not is_overall %}selected{% endif %}>
+                Current
+            </option>
+            <option value="overall"
+                {% if is_overall %}selected{% endif %}>
+                Overall
+            </option>
+            {% for s in seasons %}
+                <option value="{{ s.number }}"
+                    {% if selected_season_number == s.number %}selected{% endif %}>
+                    Season #{{ s.number }}
+                </option>
+            {% endfor %}
+        </select>
+    </div>
+</div>
+<script>
+    (function() {
+        var select = document.getElementById('season-select');
+        if (!select) return;
+        select.addEventListener('change', function() {
+            var season = this.value;
+            var urls = {
+                overview: "{{ url_for('players.overview', steam_id=player.steam_id) }}",
+                heroes: "{{ url_for('players.heroes', steam_id=player.steam_id) }}",
+                matches: "{{ url_for('players.matches', steam_id=player.steam_id) }}",
+                teammates: "{{ url_for('players.teammates', steam_id=player.steam_id) }}",
+                opponents: "{{ url_for('players.opponents', steam_id=player.steam_id) }}"
+            };
+            var current = "{{ endpoint[1] }}";
+            var baseUrl = urls[current] || urls.overview;
+            var newUrl = baseUrl;
+            if (season) {
+                var sep = baseUrl.indexOf('?') === -1 ? '?' : '&';
+                newUrl = baseUrl + sep + 'season=' + encodeURIComponent(season);
+            }
+            window.location.href = newUrl;
+        });
+    })();
+</script>

--- a/gleague/gleague/frontend/templates/matches.html
+++ b/gleague/gleague/frontend/templates/matches.html
@@ -127,7 +127,7 @@
         </div>
     {% endfor %}
 
-    {{ macro.render_pagination(matches, 'matches.matches_preview')}}
+    {{ macro.render_pagination(matches, 'matches.matches_preview', season=season, hero=hero)}}
 
 {% endblock %}
 

--- a/gleague/gleague/frontend/templates/player/heroes.html
+++ b/gleague/gleague/frontend/templates/player/heroes.html
@@ -20,31 +20,31 @@
                 <tr>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.heroes', steam_id=player.steam_id, sort='hero',
-                        desc=macro.render_desc(sort, desc, 'hero', 'no')) }}">Hero
+                        desc=macro.render_desc(sort, desc, 'hero', 'no'), season=selected_season_param) }}">Hero
                             {{ macro.render_sort_icon(sort, desc, 'hero') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.heroes', steam_id=player.steam_id, sort='played',
-                        desc=macro.render_desc(sort, desc, 'played')) }}">Matches
+                        desc=macro.render_desc(sort, desc, 'played'), season=selected_season_param) }}">Matches
                             {{ macro.render_sort_icon(sort, desc, 'played') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.heroes', steam_id=player.steam_id, sort='winrate',
-                        desc=macro.render_desc(sort, desc, 'winrate')) }}">Winrate
+                        desc=macro.render_desc(sort, desc, 'winrate'), season=selected_season_param) }}">Winrate
                             {{ macro.render_sort_icon(sort, desc, 'winrate') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.heroes', steam_id=player.steam_id, sort='pts_diff',
-                        desc=macro.render_desc(sort, desc, 'pts_diff')) }}">Earned pts
+                        desc=macro.render_desc(sort, desc, 'pts_diff'), season=selected_season_param) }}">Earned pts
                             {{ macro.render_sort_icon(sort, desc, 'pts_diff') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.heroes', steam_id=player.steam_id, sort='kda',
-                        desc=macro.render_desc(sort, desc, 'kda')) }}">KDA
+                        desc=macro.render_desc(sort, desc, 'kda'), season=selected_season_param) }}">KDA
                             {{ macro.render_sort_icon(sort, desc, 'kda') }}
                         </a>
                     </th>
@@ -52,7 +52,8 @@
                 </thead>
                 <tbody id="heroes_stats">
                 {% for s in heroes_stats %}
-                    <tr hero={{ s.hero }}>
+                    <tr class="player-hero-row clickable"
+                        data-url="{{ url_for('players.matches', steam_id=player.steam_id, season=selected_season_param, hero=s.hero) }}">
                         <td><img class="steam_img"
                                  src={{ config.SITE_PROTOCOL }}://cdn.steamstatic.com/apps/dota2/images/dota_react/heroes/{{ s.hero }}.png></td>
                         <td>{{ s.played }}</td>
@@ -74,6 +75,10 @@
                 readOnly: true,
                 path: 'https://cdnjs.cloudflare.com/ajax/libs/raty/2.8.0/images',
                 score: parseFloat("{{ avg_rating }}")
+            });
+
+            $('.player-hero-row').on('click', function (e) {
+                window.location = $(this).data('url');
             });
         });
     </script>

--- a/gleague/gleague/frontend/templates/player/matches.html
+++ b/gleague/gleague/frontend/templates/player/matches.html
@@ -77,9 +77,9 @@
             </table>
 
             {% if hero_filter %}
-                {{ macro.render_pagination(matches_stats, 'players.matches', steam_id=player.steam_id, hero=hero_filter) }}
+                {{ macro.render_pagination(matches_stats, 'players.matches', steam_id=player.steam_id, hero=hero_filter, season=selected_season_param) }}
             {% else %}
-                {{ macro.render_pagination(matches_stats, 'players.matches', steam_id=player.steam_id) }}
+                {{ macro.render_pagination(matches_stats, 'players.matches', steam_id=player.steam_id, season=selected_season_param) }}
             {% endif %}
         </div>
     </div>

--- a/gleague/gleague/frontend/templates/player/opponents.html
+++ b/gleague/gleague/frontend/templates/player/opponents.html
@@ -22,31 +22,31 @@
                     </th>
                     <th>
                         <a class="link_alt"href="{{ url_for('players.opponents', steam_id=player.steam_id, sort='nickname',
-                                desc=macro.render_desc(sort, desc, 'nickname', 'no')) }}">Player
+                                desc=macro.render_desc(sort, desc, 'nickname', 'no'), season=selected_season_param) }}">Player
                             {{ macro.render_sort_icon(sort, desc, 'nickname') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.opponents', steam_id=player.steam_id, sort='winrate',
-                                desc=macro.render_desc(sort, desc, 'winrate')) }}">Winrate
+                                desc=macro.render_desc(sort, desc, 'winrate'), season=selected_season_param) }}">Winrate
                             {{ macro.render_sort_icon(sort, desc, 'winrate') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.opponents', steam_id=player.steam_id, sort='win_loss',
-                                desc=macro.render_desc(sort, desc, 'win_loss')) }}">W-L
+                                desc=macro.render_desc(sort, desc, 'win_loss'), season=selected_season_param) }}">W-L
                             {{ macro.render_sort_icon(sort, desc, 'win_loss') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.opponents', steam_id=player.steam_id, sort='pts_diff',
-                                desc=macro.render_desc(sort, desc, 'pts_diff')) }}">PTS Diff
+                                desc=macro.render_desc(sort, desc, 'pts_diff'), season=selected_season_param) }}">PTS Diff
                             {{ macro.render_sort_icon(sort, desc, 'pts_diff') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.opponents', steam_id=player.steam_id, sort='games_played',
-                                desc=macro.render_desc(sort, desc, 'games_played')) }}">Games Against
+                                desc=macro.render_desc(sort, desc, 'games_played'), season=selected_season_param) }}">Games Against
                             {{ macro.render_sort_icon(sort, desc, 'games_played') }}
                         </a>
                     </th>
@@ -59,7 +59,7 @@
                             <img class="steam_img" src={{ opp.player.avatar_medium }}>
                         </td>
                         <td>
-                            <a href="{{ url_for('players.overview', steam_id=opp.player.steam_id) }}">
+                            <a href="{{ url_for('players.overview', steam_id=opp.player.steam_id, season=selected_season_param) }}">
                                 {{ opp.player.nickname }}
                             </a>
                         </td>

--- a/gleague/gleague/frontend/templates/player/overview.html
+++ b/gleague/gleague/frontend/templates/player/overview.html
@@ -23,12 +23,12 @@
     </thead>
     <tbody>
     {% for tm in team_mates %}
-        <tr>
+        <tr class="team-mate-row clickable" data-player="{{ tm.player_2.steam_id }}">
             <td>
                 <img class="steam_img" src={{ tm.player_2.avatar_medium }}>
             </td>
             <td>
-                <a href="{{ url_for('players.overview', steam_id=tm.player_2.steam_id) }}">
+                <a href="{{ url_for('players.overview', steam_id=tm.player_2.steam_id, season=selected_season_param) }}">
                     {{ tm.player_2.nickname }}
                 </a>
             </td>
@@ -56,12 +56,12 @@
     </thead>
     <tbody>
     {% for op in opponenets %}
-        <tr>
+        <tr class="opponent-row clickable" data-player="{{ op.player.steam_id }}">
             <td>
                 <img class="steam_img" src={{ op.player.avatar_medium }}>
             </td>
             <td>
-                <a href="{{ url_for('players.overview', steam_id=op.player.steam_id) }}">
+                <a href="{{ url_for('players.overview', steam_id=op.player.steam_id, season=selected_season_param) }}">
                     {{ op.player.nickname }}
                 </a>
             </td>
@@ -83,7 +83,7 @@
         <div class="col-6">
             <div class="card profile-row-1">
                 <div class="card-header">
-                    <a href="{{ url_for('players.heroes', steam_id=player.steam_id) }}" target="_blank">Signature Heroes&nbsp;<i class="fas fa-link"></i></a>
+                    <a href="{{ url_for('players.heroes', steam_id=player.steam_id, season=selected_season_param) }}" target="_blank">Signature Heroes&nbsp;<i class="fas fa-link"></i></a>
                 </div>
                 <div class="card-body">
                     <table class="table table-sm table-borderless table-hover">
@@ -99,7 +99,8 @@
                         </thead>
                         <tbody id="signature_heroes">
                         {% for s in signature_heroes %}
-                            <tr hero={{ s.hero }} class="clickable">
+                            <tr class="clickable signature-hero-row"
+                                data-hero="{{ s.hero }}">
                                 <td><img class="steam_img"
                                          src={{ config.SITE_PROTOCOL }}://cdn.steamstatic.com/apps/dota2/images/dota_react/heroes/{{ s.hero }}.png></td>
                                 <td>{{ s.played }}</td>
@@ -119,7 +120,7 @@
 
             {% macro render_playstyle(ps) %}
                 {% if ps %}
-                    <tr>
+                    <tr class="playstyle-row clickable" data-role="{{ ps.name }}">
                         <td>{{ ps.name }}</td>
                         <td>{{ ps.played }}</td>
                         <td>{{ '%i' % ps.winrate }}%</td>
@@ -168,7 +169,7 @@
 
             <div class="card profile-row-1">
                 <div class="card-header">
-                    <a href="{{ url_for('players.teammates', steam_id=player.steam_id, sort='win_loss') }}" target="_blank">
+                    <a href="{{ url_for('players.teammates', steam_id=player.steam_id, sort='win_loss', season=selected_season_param) }}" target="_blank">
                         Best Teammates&nbsp;<i class="fas fa-link"></i>
                     </a>
                 </div>
@@ -179,7 +180,7 @@
 
             <div class="card ">
                 <div class="card-header">
-                    <a href="{{ url_for('players.opponents', steam_id=player.steam_id, sort='win_loss') }}" target="_blank">
+                    <a href="{{ url_for('players.opponents', steam_id=player.steam_id, sort='win_loss', season=selected_season_param) }}" target="_blank">
                         Free Pts (Often Wins against)&nbsp;<i class="fas fa-link"></i>
                     </a>
                 </div>
@@ -203,7 +204,7 @@
 
             <div class="card ">
                 <div class="card-header">
-                    <a href="{{ url_for('players.teammates', steam_id=player.steam_id, sort='win_loss', desc='no') }}" target="_blank">
+                    <a href="{{ url_for('players.teammates', steam_id=player.steam_id, sort='win_loss', desc='no', season=selected_season_param) }}" target="_blank">
                         Worst Teammates&nbsp;<i class="fas fa-link"></i>
                     </a>
                 </div>
@@ -214,7 +215,7 @@
 
             <div class="card ">
                 <div class="card-header">
-                    <a href="{{ url_for('players.opponents', steam_id=player.steam_id, sort='win_loss', desc='no') }}" target="_blank">
+                    <a href="{{ url_for('players.opponents', steam_id=player.steam_id, sort='win_loss', desc='no', season=selected_season_param) }}" target="_blank">
                         Personal Nightmare (Often Losses to)&nbsp;<i class="fas fa-link"></i>
                     </a>
                 </div>
@@ -238,8 +239,10 @@
                         </thead>
                         <tbody>
                         {% for ss in player.season_stats %}
-                            <tr>
-                                <td>{{ ss.season.number }}</td>
+                            <tr class="season-row clickable" data-season="{{ ss.season.number }}">
+                                <td>
+                                    {{ ss.season.number }}
+                                </td>
                                 <td>{{ ss.wins }} / {{ ss.losses }}</td>
                                 <td>{{ ss.pts }}</td>
                             </tr>
@@ -255,7 +258,7 @@
         <div class="col-12">
             <div class="card">
                 <div class="card-header">
-                    <a href="{{ url_for('players.matches', steam_id=player.steam_id) }}" target="_blank">Matches&nbsp;<i class="fas fa-link"></i></a>
+                    <a href="{{ url_for('players.matches', steam_id=player.steam_id, season=selected_season_param) }}" target="_blank">Matches&nbsp;<i class="fas fa-link"></i></a>
                 </div>
                 <div class="card-body">
                     <table id="player_matches" class="table table-sm">
@@ -361,9 +364,70 @@
         $('.start_time').each(function() {
             $(this).html(moment(moment.unix($(this).html())).format('MMMM Do YYYY, h:mm:ss a'));
         });
-        $('#signature_heroes tr').each(function() {
+        // Signature heroes -> matches with this hero (respect season filter)
+        $('#signature_heroes tr.signature-hero-row').each(function() {
             $(this).click(function() {
-                window.location.href = '/players/{{ player.steam_id }}/matches?hero=' + $(this).attr('hero');
+                var url = "{{ url_for('players.matches', steam_id=player.steam_id) }}";
+                var params = [];
+                {% if selected_season_param %}
+                params.push("season={{ selected_season_param }}");
+                {% endif %}
+                params.push("hero=" + $(this).data('hero'));
+                window.location.href = url + "?" + params.join("&");
+            });
+        });
+
+        // Playstyle rows -> matches with this role
+        $('tr.playstyle-row').each(function() {
+            $(this).click(function() {
+                var url = "{{ url_for('players.matches', steam_id=player.steam_id) }}";
+                var params = [];
+                {% if selected_season_param %}
+                params.push("season={{ selected_season_param }}");
+                {% endif %}
+                params.push("role=" + encodeURIComponent($(this).data('role')));
+                window.location.href = url + "?" + params.join("&");
+            });
+        });
+
+        // Best / worst teammates -> matches with this teammate
+        $('tr.team-mate-row').each(function() {
+            $(this).click(function(e) {
+                if ($(e.target).closest('a').length) {
+                    return;
+                }
+                var url = "{{ url_for('players.matches', steam_id=player.steam_id) }}";
+                var params = [];
+                {% if selected_season_param %}
+                params.push("season={{ selected_season_param }}");
+                {% endif %}
+                params.push("teammate=" + $(this).data('player'));
+                window.location.href = url + "?" + params.join("&");
+            });
+        });
+
+        // Free Pts / Personal Nightmare -> matches vs this opponent
+        $('tr.opponent-row').each(function() {
+            $(this).click(function(e) {
+                if ($(e.target).closest('a').length) {
+                    return;
+                }
+                var url = "{{ url_for('players.matches', steam_id=player.steam_id) }}";
+                var params = [];
+                {% if selected_season_param %}
+                params.push("season={{ selected_season_param }}");
+                {% endif %}
+                params.push("opponent=" + $(this).data('player'));
+                window.location.href = url + "?" + params.join("&");
+            });
+        });
+
+        // Seasons played -> matches from this season
+        $('tr.season-row').each(function() {
+            $(this).click(function() {
+                var url = "{{ url_for('players.matches', steam_id=player.steam_id) }}";
+                var params = ["season=" + $(this).data('season')];
+                window.location.href = url + "?" + params.join("&");
             });
         });
         $('#player_matches tbody > tr').each(function() {

--- a/gleague/gleague/frontend/templates/player/teammates.html
+++ b/gleague/gleague/frontend/templates/player/teammates.html
@@ -22,32 +22,32 @@
                     </th>
                     <th>
                         <a class="link_alt"href="{{ url_for('players.teammates', steam_id=player.steam_id, sort='nickname',
-                                desc=macro.render_desc(sort, desc, 'nickname', 'no')) }}">Player
+                                desc=macro.render_desc(sort, desc, 'nickname', 'no'), season=selected_season_param) }}">Player
                             {{ macro.render_sort_icon(sort, desc, 'nickname') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.teammates', steam_id=player.steam_id, sort='winrate',
-                                desc=macro.render_desc(sort, desc, 'winrate')) }}">Winrate
+                                desc=macro.render_desc(sort, desc, 'winrate'), season=selected_season_param) }}">Winrate
                             {{ macro.render_sort_icon(sort, desc, 'winrate') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.teammates', steam_id=player.steam_id, sort='win_loss',
-                                desc=macro.render_desc(sort, desc, 'win_loss')) }}">W-L
+                                desc=macro.render_desc(sort, desc, 'win_loss'), season=selected_season_param) }}">W-L
                             {{ macro.render_sort_icon(sort, desc, 'win_loss') }}
                         </a>
                     </th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.teammates', steam_id=player.steam_id, sort='pts_diff',
-                                desc=macro.render_desc(sort, desc, 'pts_diff')) }}">PTS Diff
+                                desc=macro.render_desc(sort, desc, 'pts_diff'), season=selected_season_param) }}">PTS Diff
                             {{ macro.render_sort_icon(sort, desc, 'pts_diff') }}
                         </a>
                     </th>
                     <th></th>
                     <th>
                         <a class="link_alt" href="{{ url_for('players.teammates', steam_id=player.steam_id, sort='games_played',
-                                desc=macro.render_desc(sort, desc, 'games_played')) }}">Games Together
+                                desc=macro.render_desc(sort, desc, 'games_played'), season=selected_season_param) }}">Games Together
                             {{ macro.render_sort_icon(sort, desc, 'games_played') }}
                         </a>
                     </th>
@@ -60,7 +60,7 @@
                             <img class="steam_img" src={{ mate.player_2.avatar_medium }}>
                         </td>
                         <td>
-                            <a href="{{ url_for('players.overview', steam_id=mate.player_2.steam_id) }}">
+                            <a href="{{ url_for('players.overview', steam_id=mate.player_2.steam_id, season=selected_season_param) }}">
                                 {{ mate.player_2.nickname }}
                             </a>
                         </td>

--- a/gleague/gleague/frontend/templates/season/heroes.html
+++ b/gleague/gleague/frontend/templates/season/heroes.html
@@ -66,13 +66,17 @@
                     </thead>
                     <tbody>
                     {% for h in in_season_heroes %}
-                    <tr>
+                    <tr class="season-hero-row"
+                        data-url="{{ url_for('matches.matches_preview', season=season_number, hero=h.hero_name) }}">
                         <td>
                             <img class="steam_img"
                         src={{ config.SITE_PROTOCOL }}://cdn.steamstatic.com/apps/dota2/images/dota_react/heroes/{{ h.hero_name }}.png>&nbsp;
                         </td>
                         <td>
-                            {{ h.hero_human_readable }}
+                            <a class="link_alt"
+                               href="{{ url_for('matches.matches_preview', season=season_number, hero=h.hero_name) }}">
+                                {{ h.hero_human_readable }}
+                            </a>
                         </td>
                         <td>{{ h.pick_count }}</td>
                         <td>{{ h.ban_count }}</td>
@@ -87,4 +91,17 @@
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block script %}
+    <script>
+        $(function () {
+            $('.season-hero-row').css('cursor', 'pointer').on('click', function (e) {
+                if (e.target.tagName.toLowerCase() === 'a') {
+                    return;
+                }
+                window.location = $(this).data('url');
+            });
+        });
+    </script>
 {% endblock %}

--- a/gleague/gleague/models/queries/player_analytic.py
+++ b/gleague/gleague/models/queries/player_analytic.py
@@ -7,12 +7,13 @@ from gleague.models import PlayerMatchStats
 from gleague.models import SeasonStats
 
 
-def get_pts_history(steam_id, season_id):
+def get_pts_history(steam_id, season_id=None):
+    filters = SeasonStats.steam_id == steam_id
+    if season_id is not None:
+        filters = and_(filters, SeasonStats.season_id == season_id)
     pts_seq = (
         PlayerMatchStats.query.join(SeasonStats)
-        .filter(
-            and_(SeasonStats.season_id == season_id, SeasonStats.steam_id == steam_id)
-        )
+        .filter(filters)
         .order_by(PlayerMatchStats.match_id)
         .values(PlayerMatchStats.old_pts + PlayerMatchStats.pts_diff)
     )
@@ -52,11 +53,14 @@ def get_heroes(steam_id, season_id=None):
     return query
 
 
-def get_rating_info(steam_id):
+def get_rating_info(steam_id, season_id=None):
+    filters = SeasonStats.steam_id == steam_id
+    if season_id is not None:
+        filters = and_(filters, SeasonStats.season_id == season_id)
     rating_info = (
         PlayerMatchRating.query.join(PlayerMatchStats)
         .join(SeasonStats)
-        .filter(SeasonStats.steam_id == steam_id)
+        .filter(filters)
         .with_entities(
             func.avg(PlayerMatchRating.rating), func.count(PlayerMatchRating.id)
         )


### PR DESCRIPTION
1. Добавлен расчёт героев сезона через PlayerMatchStats, чтобы страница Season → Heroes работала даже для ранних сезонов без распарсенных пиков; баны подтягиваются из CMPicksBans при наличии данных.
2. Исправлен алгоритм get_signature_teammates: пары игроков нормализуются, благодаря чему тиммейты больше не дублируются и корректно считаются PTS diff для обоих.

4. Для профиля игрока добавлены переходы в матч‑лист с учётом фильтра по сезону:
- из Signature Heroes и страницы Heroes → матчи на выбранном герое;
- из блока Playstyle → матчи на выбранной роли (safelane/offlane/midlane/support);
- из Best/Worst Teammates → матчи с выбранным тиммейтом;
- из Free Pts / Personal Nightmare → матчи против выбранного соперника;
 - из Seasons played → все матчи игрока в выбранном сезоне.

5. Страница Match History (/matches) получила фильтры по сезону и герою, пагинация сохраняет эти параметры.
6. Для Season: Overall в карточке игрока победы/поражения теперь считаются по реальным матчам, чтобы совпадать с вкладками Heroes и Matches.